### PR TITLE
build(Dockerfile): removes g option for npm install in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -83,7 +83,7 @@ COPY --from=node-slim --chown=${USER}:${USER} /usr/local/nvm /usr/local/nvm
 RUN bash -c ". $NVM_DIR/nvm.sh && nvm install $NODE_VERSION && nvm alias default $NODE_VERSION && nvm use default"
 
 
-RUN npm install npm -g
+RUN npm install npm
 RUN npm install yarn -g
 
 # Install PNPM


### PR DESCRIPTION
Removes the `-g` flag within `npm install npm` causing the Dockerfile build to break