### PR TITLE
fix: add missing 'fi' in install script

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -5,9 +5,9 @@ cargo install cargo-binstall
 cargo binstall cargo-risczero
 cargo risczero install
 
-#check os linux or mac
+# check os linux or mac
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-    //check is nvidia-smi exists
+    # check if nvidia-smi exists
     if ! command -v nvidia-smi &> /dev/null
     then
         echo "installing without cuda support, proving will be slower"
@@ -18,3 +18,4 @@ if [[ "$OSTYPE" == "linux-gnu"* ]]; then
     fi
 elif [[ "$OSTYPE" == "darwin"* ]]; then
     cargo install bonsol-cli --git https://github.com/anagrambuild/bonsol --features mac
+fi


### PR DESCRIPTION
fix: add missing 'fi' in install script

The install script for `bonsol-cli` is failing on Linux with the error:
`sh: 21: Syntax error: end of file unexpected (expecting "fi")`

From logs:
```bash
ubuntu@ip-172-31-37-102:~/hello_bonsol/zkprograms$ # Install Bonsol CLI, Risc0 Toolchain
curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/anagrambuild/bonsol/refs/heads/main/bin/install.sh | sh
    Updating crates.io index
     Ignored package `cargo-binstall v1.10.23` is already installed, use --force to override
 INFO resolve: Resolving package: 'cargo-risczero'
 INFO resolve: cargo-risczero v1.2.3 is already installed, use --force to override
 INFO Done in 436.277687ms
Getting release info: https://api.github.com/repos/risc0/toolchain/releases/tags/2024.01.05...
Toolchain path /home/ubuntu/.local/share/cargo-risczero/toolchains/c_x86_64-unknown-linux-gnu_2024.01.05 already exists - deleting existing files!
Downloading c toolchain from url 'https://github.com/risc0/toolchain/releases/download/2024.01.05/riscv32im-linux-x86_64.tar.xz'...
Extracting...
Downloaded c toolchain to /home/ubuntu/.local/share/cargo-risczero/toolchains/c_x86_64-unknown-linux-gnu_2024.01.05
Getting release info: https://api.github.com/repos/risc0/rust/releases/latest...
Toolchain path /home/ubuntu/.local/share/cargo-risczero/toolchains/rust_x86_64-unknown-linux-gnu_r0.1.81.0 already exists - deleting existing files!
Downloading rust toolchain from url 'https://github.com/risc0/rust/releases/download/r0.1.81.0/rust-toolchain-x86_64-unknown-linux-gnu.tar.gz'...
Extracting...
Downloaded rust toolchain x86_64-unknown-linux-gnu to /home/ubuntu/.local/share/cargo-risczero/toolchains/rust_x86_64-unknown-linux-gnu_r0.1.81.0
Activating rustup toolchain risc0 at /home/ubuntu/.local/share/cargo-risczero/toolchains/rust_x86_64-unknown-linux-gnu_r0.1.81.0...
info: uninstalling toolchain 'risc0'
info: toolchain 'risc0' uninstalled
Running rustup toolchain link risc0 /home/ubuntu/.local/share/cargo-risczero/toolchains/rust_x86_64-unknown-linux-gnu_r0.1.81.0:
rustup toolchain risc0 was linked and is now available!
Rust Toolchain risc0 downloaded and installed to path /home/ubuntu/.local/share/cargo-risczero/toolchains/rust_x86_64-unknown-linux-gnu_r0.1.81.0.
C Toolchain downloaded and installed to path /home/ubuntu/.local/share/cargo-risczero/cpp.
The risc0 toolchain is now ready to use.
sh: 21: Syntax error: end of file unexpected (expecting "fi")
```
