### PR TITLE
Fix CI: Conditionally build and load Docker images for fork PRs

### DIFF
--- a/.github/workflows/build-node-containers.yaml
+++ b/.github/workflows/build-node-containers.yaml
@@ -2,6 +2,11 @@ name: Build Bonsol node images
 
 on:
   workflow_call:
+    inputs:
+      is_fork:
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   build-node-container-image:
@@ -20,6 +25,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Login to GitHub Container Registry
+        if: ${{ !inputs.is_fork }}
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -42,40 +48,47 @@ jobs:
             # For main branch pushes, use flavor-{commit_sha}
             echo "TAG=${{ github.sha }}" >> $GITHUB_OUTPUT
           fi
+          # Set local image names for fork PRs
+          echo "SLIM_LOCAL_NAME=bonsol-node:slim-${{ github.sha }}" >> $GITHUB_OUTPUT
+          echo "STARK_LOCAL_NAME=bonsol-node:stark-${{ github.sha }}" >> $GITHUB_OUTPUT
+          echo "STARK_CUDA_LOCAL_NAME=bonsol-node:stark-cuda-${{ github.sha }}" >> $GITHUB_OUTPUT
 
-      - name: Build and Push Docker Image slim
+      - name: Build Docker Image slim
         uses: docker/build-push-action@v6
         with:
           context: .
-          push: true
+          push: ${{ !inputs.is_fork }}
+          load: ${{ inputs.is_fork }}
           file: docker/Dockerfile.slim
-          tags: ${{ steps.docker_tags.outputs.REGISTRY }}:slim-${{ steps.docker_tags.outputs.TAG }}
+          tags: ${{ inputs.is_fork && steps.docker_tags.outputs.SLIM_LOCAL_NAME || format('{0}:slim-{1}', steps.docker_tags.outputs.REGISTRY, steps.docker_tags.outputs.TAG) }}
           platforms: linux/amd64
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Build and Push Docker Image start
+      - name: Build Docker Image stark
         uses: docker/build-push-action@v6
         with:
           context: .
-          push: true
+          push: ${{ !inputs.is_fork }}
+          load: ${{ inputs.is_fork }}
           file: docker/Dockerfile.stark
-          tags: ${{ steps.docker_tags.outputs.REGISTRY }}:stark-${{ steps.docker_tags.outputs.TAG }}
+          tags: ${{ inputs.is_fork && steps.docker_tags.outputs.STARK_LOCAL_NAME || format('{0}:stark-{1}', steps.docker_tags.outputs.REGISTRY, steps.docker_tags.outputs.TAG) }}
           platforms: linux/amd64
           build-args: |
-            IMAGE=${{ steps.docker_tags.outputs.REGISTRY }}:slim-${{ steps.docker_tags.outputs.TAG }}
+            IMAGE=${{ inputs.is_fork && steps.docker_tags.outputs.SLIM_LOCAL_NAME || format('{0}:slim-{1}', steps.docker_tags.outputs.REGISTRY, steps.docker_tags.outputs.TAG) }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Build and Push Docker Image full
+      - name: Build Docker Image full
         uses: docker/build-push-action@v6
         with:
           context: .
-          push: true
+          push: ${{ !inputs.is_fork }}
+          load: ${{ inputs.is_fork }}
           file: docker/Dockerfile.full
-          tags: ${{ steps.docker_tags.outputs.REGISTRY }}:stark-cuda-${{ steps.docker_tags.outputs.TAG }}
+          tags: ${{ inputs.is_fork && steps.docker_tags.outputs.STARK_CUDA_LOCAL_NAME || format('{0}:stark-cuda-{1}', steps.docker_tags.outputs.REGISTRY, steps.docker_tags.outputs.TAG) }}
           platforms: linux/amd64
           build-args: |
-            IMAGE=${{ steps.docker_tags.outputs.REGISTRY }}:stark-${{ steps.docker_tags.outputs.TAG }}
+            IMAGE=${{ inputs.is_fork && steps.docker_tags.outputs.STARK_LOCAL_NAME || format('{0}:stark-{1}', steps.docker_tags.outputs.REGISTRY, steps.docker_tags.outputs.TAG) }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/pr-workflow.yaml
+++ b/.github/workflows/pr-workflow.yaml
@@ -71,21 +71,41 @@ jobs:
       - name: Test
         run: cargo test -- --nocapture
 
+  check-fork-pr:
+    name: Check if PR is from fork
+    runs-on: ubuntu-latest
+    outputs:
+      is_fork: ${{ steps.check.outputs.is_fork }}
+    steps:
+      - name: Check if PR is from fork
+        id: check
+        run: |
+          if [[ "${{ github.event.pull_request.head.repo.fork }}" == "true" ]]; then
+            echo "is_fork=true" >> $GITHUB_OUTPUT
+            echo "PR is from a fork repository"
+          else
+            echo "is_fork=false" >> $GITHUB_OUTPUT
+            echo "PR is from the same repository"
+          fi
+
   call-build-node-container-image:
     permissions:
       contents: read
       packages: write
+    needs: check-fork-pr
     uses: ./.github/workflows/build-node-containers.yaml
+    with:
+      is_fork: ${{ needs.check-fork-pr.outputs.is_fork == 'true' }}
 
   e2e-test:
 
     name: E2E Test
     runs-on:
       labels: ubicloud-standard-30
-    needs: call-build-node-container-image
+    needs: [call-build-node-container-image, check-fork-pr]
 
     container:
-      image: ghcr.io/bonsol-collective/bonsol-node:stark-cuda-${{ github.sha }}
+      image: ${{ needs.check-fork-pr.outputs.is_fork == 'true' && 'bonsol-node:stark-cuda-' || 'ghcr.io/bonsol-collective/bonsol-node:stark-cuda-' }}${{ github.sha }}
       options: "-it"
       volumes:
         - local:/workspaces/bonsol
@@ -99,7 +119,7 @@ jobs:
         run: |
           set -euxo pipefail
           cd /usr/opt/bonsol/
-          echo "Using image ghcr.io/bonsol-collective/bonsol-node:stark-cuda-${{ github.sha }}"
+          echo "Using image ${{ needs.check-fork-pr.outputs.is_fork == 'true' && 'bonsol-node:stark-cuda-' || 'ghcr.io/bonsol-collective/bonsol-node:stark-cuda-' }}${{ github.sha }}"
           git clone https://github.com/bonsol-collective/bonsol.git src
           cp -pr src/elf .
           solana-keygen new -s --no-bip39-passphrase -f


### PR DESCRIPTION
Fix CI failures for PRs from forked repositories.

## Problem
CI builds have been failing for PRs from forked repositories due to permission issues when trying to push Docker images to the GitHub Container Registry.

## Solution
Modify the CI workflow to:
1. Detect if a PR comes from a fork repository
2. For fork PRs, build Docker images and load them into the local Docker daemon (instead of pushing to registry)
3. Update E2E tests to use local images for fork PRs

Goal is to have all PRs (internal and from forks) be tested in full before merging.