### PR TITLE
Fix CI: Improve Docker image handling for fork PRs

### DIFF
--- a/.github/workflows/build-node-containers.yaml
+++ b/.github/workflows/build-node-containers.yaml
@@ -47,13 +47,13 @@ jobs:
             # For main branch pushes, use flavor-{commit_sha}
             echo "TAG=${{ github.sha }}" >> $GITHUB_OUTPUT
           fi
-          
+
           # Registry and image names for non-fork PRs
           echo "REGISTRY=ghcr.io/bonsol-collective/bonsol-node" >> $GITHUB_OUTPUT
           echo "SLIM_IMAGE=ghcr.io/bonsol-collective/bonsol-node:slim-${{ github.sha }}" >> $GITHUB_OUTPUT
           echo "STARK_IMAGE=ghcr.io/bonsol-collective/bonsol-node:stark-${{ github.sha }}" >> $GITHUB_OUTPUT
           echo "STARK_CUDA_IMAGE=ghcr.io/bonsol-collective/bonsol-node:stark-cuda-${{ github.sha }}" >> $GITHUB_OUTPUT
-          
+
           # Local image names for fork PRs - use consistent naming without registry prefix
           echo "LOCAL_SLIM_IMAGE=bonsol-node-slim:latest" >> $GITHUB_OUTPUT
           echo "LOCAL_STARK_IMAGE=bonsol-node-stark:latest" >> $GITHUB_OUTPUT

--- a/.github/workflows/build-node-containers.yaml
+++ b/.github/workflows/build-node-containers.yaml
@@ -58,7 +58,7 @@ jobs:
           echo "LOCAL_SLIM_IMAGE=bonsol-node-slim:latest" >> $GITHUB_OUTPUT
           echo "LOCAL_STARK_IMAGE=bonsol-node-stark:latest" >> $GITHUB_OUTPUT
           echo "LOCAL_STARK_CUDA_IMAGE=bonsol-node-stark-cuda:latest" >> $GITHUB_OUTPUT
-          
+
       - name: Build Docker Image slim
         uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/build-node-containers.yaml
+++ b/.github/workflows/build-node-containers.yaml
@@ -40,7 +40,6 @@ jobs:
       - name: Set Docker Tags
         id: docker_tags
         run: |
-          echo "REGISTRY=ghcr.io/bonsol-collective/bonsol-node" >> $GITHUB_OUTPUT
           if [[ "${{ github.ref_type }}" == "tag" ]]; then
             # For tag releases, use flavor-v{version}
             echo "TAG=${{ github.ref_name }}" >> $GITHUB_OUTPUT
@@ -48,10 +47,17 @@ jobs:
             # For main branch pushes, use flavor-{commit_sha}
             echo "TAG=${{ github.sha }}" >> $GITHUB_OUTPUT
           fi
-          # Set local image names for fork PRs
-          echo "SLIM_LOCAL_NAME=bonsol-node:slim-${{ github.sha }}" >> $GITHUB_OUTPUT
-          echo "STARK_LOCAL_NAME=bonsol-node:stark-${{ github.sha }}" >> $GITHUB_OUTPUT
-          echo "STARK_CUDA_LOCAL_NAME=bonsol-node:stark-cuda-${{ github.sha }}" >> $GITHUB_OUTPUT
+          
+          # Registry and image names for non-fork PRs
+          echo "REGISTRY=ghcr.io/bonsol-collective/bonsol-node" >> $GITHUB_OUTPUT
+          echo "SLIM_IMAGE=ghcr.io/bonsol-collective/bonsol-node:slim-${{ github.sha }}" >> $GITHUB_OUTPUT
+          echo "STARK_IMAGE=ghcr.io/bonsol-collective/bonsol-node:stark-${{ github.sha }}" >> $GITHUB_OUTPUT
+          echo "STARK_CUDA_IMAGE=ghcr.io/bonsol-collective/bonsol-node:stark-cuda-${{ github.sha }}" >> $GITHUB_OUTPUT
+          
+          # Local image names for fork PRs - use consistent naming without registry prefix
+          echo "LOCAL_SLIM_IMAGE=bonsol-node-slim:latest" >> $GITHUB_OUTPUT
+          echo "LOCAL_STARK_IMAGE=bonsol-node-stark:latest" >> $GITHUB_OUTPUT
+          echo "LOCAL_STARK_CUDA_IMAGE=bonsol-node-stark-cuda:latest" >> $GITHUB_OUTPUT
 
       - name: Build Docker Image slim
         uses: docker/build-push-action@v6
@@ -60,7 +66,7 @@ jobs:
           push: ${{ !inputs.is_fork }}
           load: ${{ inputs.is_fork }}
           file: docker/Dockerfile.slim
-          tags: ${{ inputs.is_fork && steps.docker_tags.outputs.SLIM_LOCAL_NAME || format('{0}:slim-{1}', steps.docker_tags.outputs.REGISTRY, steps.docker_tags.outputs.TAG) }}
+          tags: ${{ inputs.is_fork && steps.docker_tags.outputs.LOCAL_SLIM_IMAGE || steps.docker_tags.outputs.SLIM_IMAGE }}
           platforms: linux/amd64
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -72,10 +78,10 @@ jobs:
           push: ${{ !inputs.is_fork }}
           load: ${{ inputs.is_fork }}
           file: docker/Dockerfile.stark
-          tags: ${{ inputs.is_fork && steps.docker_tags.outputs.STARK_LOCAL_NAME || format('{0}:stark-{1}', steps.docker_tags.outputs.REGISTRY, steps.docker_tags.outputs.TAG) }}
+          tags: ${{ inputs.is_fork && steps.docker_tags.outputs.LOCAL_STARK_IMAGE || steps.docker_tags.outputs.STARK_IMAGE }}
           platforms: linux/amd64
           build-args: |
-            IMAGE=${{ inputs.is_fork && steps.docker_tags.outputs.SLIM_LOCAL_NAME || format('{0}:slim-{1}', steps.docker_tags.outputs.REGISTRY, steps.docker_tags.outputs.TAG) }}
+            IMAGE=${{ inputs.is_fork && steps.docker_tags.outputs.LOCAL_SLIM_IMAGE || steps.docker_tags.outputs.SLIM_IMAGE }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -86,9 +92,9 @@ jobs:
           push: ${{ !inputs.is_fork }}
           load: ${{ inputs.is_fork }}
           file: docker/Dockerfile.full
-          tags: ${{ inputs.is_fork && steps.docker_tags.outputs.STARK_CUDA_LOCAL_NAME || format('{0}:stark-cuda-{1}', steps.docker_tags.outputs.REGISTRY, steps.docker_tags.outputs.TAG) }}
+          tags: ${{ inputs.is_fork && steps.docker_tags.outputs.LOCAL_STARK_CUDA_IMAGE || steps.docker_tags.outputs.STARK_CUDA_IMAGE }}
           platforms: linux/amd64
           build-args: |
-            IMAGE=${{ inputs.is_fork && steps.docker_tags.outputs.STARK_LOCAL_NAME || format('{0}:stark-{1}', steps.docker_tags.outputs.REGISTRY, steps.docker_tags.outputs.TAG) }}
+            IMAGE=${{ inputs.is_fork && steps.docker_tags.outputs.LOCAL_STARK_IMAGE || steps.docker_tags.outputs.STARK_IMAGE }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/build-node-containers.yaml
+++ b/.github/workflows/build-node-containers.yaml
@@ -2,6 +2,11 @@ name: Build Bonsol node images
 
 on:
   workflow_call:
+    inputs:
+      is_fork:
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   build-node-container-image:
@@ -20,6 +25,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Login to GitHub Container Registry
+        if: ${{ !inputs.is_fork }}
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -42,40 +48,47 @@ jobs:
             # For main branch pushes, use flavor-{commit_sha}
             echo "TAG=${{ github.sha }}" >> $GITHUB_OUTPUT
           fi
+          # Set local image names for fork PRs
+          echo "SLIM_LOCAL_NAME=bonsol-node:slim-${{ github.sha }}" >> $GITHUB_OUTPUT
+          echo "STARK_LOCAL_NAME=bonsol-node:stark-${{ github.sha }}" >> $GITHUB_OUTPUT
+          echo "STARK_CUDA_LOCAL_NAME=bonsol-node:stark-cuda-${{ github.sha }}" >> $GITHUB_OUTPUT
 
-      - name: Build and Push Docker Image slim
+      - name: Build Docker Image slim
         uses: docker/build-push-action@v6
         with:
           context: .
-          push: true
+          push: ${{ !inputs.is_fork }}
+          load: ${{ inputs.is_fork }}
           file: docker/Dockerfile.slim
-          tags: ${{ steps.docker_tags.outputs.REGISTRY }}:slim-${{ steps.docker_tags.outputs.TAG }}
+          tags: ${{ inputs.is_fork && steps.docker_tags.outputs.SLIM_LOCAL_NAME || format('{0}:slim-{1}', steps.docker_tags.outputs.REGISTRY, steps.docker_tags.outputs.TAG) }}
           platforms: linux/amd64
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Build and Push Docker Image start
+      - name: Build Docker Image stark
         uses: docker/build-push-action@v6
         with:
           context: .
-          push: true
+          push: ${{ !inputs.is_fork }}
+          load: ${{ inputs.is_fork }}
           file: docker/Dockerfile.stark
-          tags: ${{ steps.docker_tags.outputs.REGISTRY }}:stark-${{ steps.docker_tags.outputs.TAG }}
+          tags: ${{ inputs.is_fork && steps.docker_tags.outputs.STARK_LOCAL_NAME || format('{0}:stark-{1}', steps.docker_tags.outputs.REGISTRY, steps.docker_tags.outputs.TAG) }}
           platforms: linux/amd64
           build-args: |
-            IMAGE=${{ steps.docker_tags.outputs.REGISTRY }}:slim-${{ steps.docker_tags.outputs.TAG }}
+            IMAGE=${{ inputs.is_fork && steps.docker_tags.outputs.SLIM_LOCAL_NAME || format('{0}:slim-{1}', steps.docker_tags.outputs.REGISTRY, steps.docker_tags.outputs.TAG) }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Build and Push Docker Image full
+      - name: Build Docker Image full
         uses: docker/build-push-action@v6
         with:
           context: .
-          push: true
+          push: ${{ !inputs.is_fork }}
+          load: ${{ inputs.is_fork }}
           file: docker/Dockerfile.full
-          tags: ${{ steps.docker_tags.outputs.REGISTRY }}:stark-cuda-${{ steps.docker_tags.outputs.TAG }}
+          tags: ${{ inputs.is_fork && steps.docker_tags.outputs.STARK_CUDA_LOCAL_NAME || format('{0}:stark-cuda-{1}', steps.docker_tags.outputs.REGISTRY, steps.docker_tags.outputs.TAG) }}
           platforms: linux/amd64
           build-args: |
-            IMAGE=${{ steps.docker_tags.outputs.REGISTRY }}:stark-${{ steps.docker_tags.outputs.TAG }}
+            IMAGE=${{ inputs.is_fork && steps.docker_tags.outputs.STARK_LOCAL_NAME || format('{0}:stark-{1}', steps.docker_tags.outputs.REGISTRY, steps.docker_tags.outputs.TAG) }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/pr-workflow.yaml
+++ b/.github/workflows/pr-workflow.yaml
@@ -71,21 +71,41 @@ jobs:
       - name: Test
         run: cargo test -- --nocapture
 
+  check-fork-pr:
+    name: Check if PR is from fork
+    runs-on: ubuntu-latest
+    outputs:
+      is_fork: ${{ steps.check.outputs.is_fork }}
+    steps:
+      - name: Check if PR is from fork
+        id: check
+        run: |
+          if [[ "${{ github.event.pull_request.head.repo.fork }}" == "true" ]]; then
+            echo "is_fork=true" >> $GITHUB_OUTPUT
+            echo "PR is from a fork repository"
+          else
+            echo "is_fork=false" >> $GITHUB_OUTPUT
+            echo "PR is from the same repository"
+          fi
+
   call-build-node-container-image:
     permissions:
       contents: read
       packages: write
+    needs: check-fork-pr
     uses: ./.github/workflows/build-node-containers.yaml
+    with:
+      is_fork: ${{ needs.check-fork-pr.outputs.is_fork == 'true' }}
 
   e2e-test:
 
     name: E2E Test
     runs-on:
       labels: ubicloud-standard-30
-    needs: call-build-node-container-image
+    needs: [call-build-node-container-image, check-fork-pr]
 
     container:
-      image: ghcr.io/bonsol-collective/bonsol-node:stark-cuda-${{ github.sha }}
+      image: ${{ needs.check-fork-pr.outputs.is_fork == 'true' && 'bonsol-node:stark-cuda-' || 'ghcr.io/bonsol-collective/bonsol-node:stark-cuda-' }}${{ github.sha }}
       options: "-it"
       volumes:
         - local:/workspaces/bonsol
@@ -99,7 +119,7 @@ jobs:
         run: |
           set -euxo pipefail
           cd /usr/opt/bonsol/
-          echo "Using image ghcr.io/bonsol-collective/bonsol-node:stark-cuda-${{ github.sha }}"
+          echo "Using image ${{ needs.check-fork-pr.outputs.is_fork == 'true' && 'bonsol-node:stark-cuda-' || 'ghcr.io/bonsol-collective/bonsol-node:stark-cuda-' }}${{ github.sha }}"
           git clone https://github.com/bonsol-collective/bonsol.git src
           cp -pr src/elf .
           solana-keygen new -s --no-bip39-passphrase -f

--- a/.github/workflows/pr-workflow.yaml
+++ b/.github/workflows/pr-workflow.yaml
@@ -105,7 +105,7 @@ jobs:
     needs: [call-build-node-container-image, check-fork-pr]
 
     container:
-      image: ${{ needs.check-fork-pr.outputs.is_fork == 'true' && 'bonsol-node:stark-cuda-' || 'ghcr.io/bonsol-collective/bonsol-node:stark-cuda-' }}${{ github.sha }}
+      image: ${{ needs.check-fork-pr.outputs.is_fork == 'true' && 'bonsol-node-stark-cuda:latest' || format('ghcr.io/bonsol-collective/bonsol-node:stark-cuda-{0}', github.sha) }}
       options: "-it"
       volumes:
         - local:/workspaces/bonsol
@@ -119,7 +119,7 @@ jobs:
         run: |
           set -euxo pipefail
           cd /usr/opt/bonsol/
-          echo "Using image ${{ needs.check-fork-pr.outputs.is_fork == 'true' && 'bonsol-node:stark-cuda-' || 'ghcr.io/bonsol-collective/bonsol-node:stark-cuda-' }}${{ github.sha }}"
+          echo "Using image ${{ needs.check-fork-pr.outputs.is_fork == 'true' && 'bonsol-node-stark-cuda:latest' || format('ghcr.io/bonsol-collective/bonsol-node:stark-cuda-{0}', github.sha) }}"
           git clone https://github.com/bonsol-collective/bonsol.git src
           cp -pr src/elf .
           solana-keygen new -s --no-bip39-passphrase -f


### PR DESCRIPTION
## Changes
Builds on #194 by:

1. Simplifying local image naming for fork PRs:
   - Using static names like `bonsol-node-slim:latest` instead of names with commit SHA
   - This ensures Docker can reliably locate images in its local registry

2. Improving variable structure:
   - Added clear, separate variables for registry images vs local images
   - Made image references more explicit

3. Updating the e2e-test to work with the new naming pattern

## Impact
- Fork PRs should now be able to build all Docker images without permission errors
- E2E tests can run properly using locally built images
- Internal PRs continue to work as before, pushing to the registry